### PR TITLE
Add baseurl to prefix all paths with

### DIFF
--- a/src/AssetRegistry.jl
+++ b/src/AssetRegistry.jl
@@ -6,9 +6,13 @@ using SHA
 using JSON
 using Pidfile
 
+const baseurl = Ref{String}("")
 const registry = Dict{String,String}()
 
 withlock(f,lockf) = (lock=mkpidlock(lockf, stale_age=5); f(); close(lock))
+
+# Need to remove the basepath for file database
+filekey(key) = key[length(baseurl[])+1:end]
 
 """
 
@@ -45,15 +49,15 @@ function register(path; registry_file = joinpath(homedir(), ".jlassetregistry.js
     pidlock = joinpath(homedir(), ".jlassetregistry.lock")
 
     withlock(pidlock) do
-
+        fkey = filekey(key)
         io = open(registry_file, "r+") # open in read-and-write mode
         # first get existing entries
         prev_registry =  filesize(io) > 0 ? JSON.parse(io) : Dict{String,Tuple{String,Int}}()
 
-        if haskey(prev_registry, key)
-            prev_registry[key] = (target, prev_registry[key][2]+1) # increment ref count
+        if haskey(prev_registry, fkey)
+            prev_registry[fkey] = (target, prev_registry[fkey][2]+1) # increment ref count
         else
-            prev_registry[key] = (target, 1) # init refcount to 1
+            prev_registry[fkey] = (target, 1) # init refcount to 1
         end
 
         # write the updated registry to file
@@ -85,17 +89,18 @@ function deregister(path; registry_file = joinpath(homedir(), ".jlassetregistry.
 
     pidlock = joinpath(homedir(), ".jlassetregistry.lock")
     withlock(pidlock) do
+        fkey = filekey(key)
         io = open(registry_file, "r+")
 
         # get existing information
         prev_registry =  filesize(io) > 0 ? JSON.parse(io) : Dict{String,Tuple{String, Int}}()
 
-        if haskey(prev_registry, key)
-            val, count = prev_registry[key]
+        if haskey(prev_registry, fkey)
+            val, count = prev_registry[fkey]
             if count == 1
-                pop!(prev_registry, key)
+                pop!(prev_registry, fkey)
             else
-                prev_registry[key] = (val, count-1) # increment ref count
+                prev_registry[fkey] = (val, count-1) # increment ref count
             end
         end
 
@@ -110,11 +115,12 @@ function deregister(path; registry_file = joinpath(homedir(), ".jlassetregistry.
     key
 end
 
-getkey(path) =  "/assetserver/" * bytes2hex(sha1(abspath(path))) * "-" * basename(path)
+getkey(path) =  baseurl[] * "/assetserver/" * bytes2hex(sha1(abspath(path))) * "-" * basename(path)
 
 isregistered(path) = haskey(registry, getkey(path))
 
 function __init__()
+    baseurl[] = get(ENV, "JULIA_ASSETREGISTRY_BASEURL", get(ENV, "JUPYTERHUB_SERVICE_PREFIX", ""))
     atexit() do
         for (key, path) in AssetRegistry.registry
             AssetRegistry.deregister(path)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,19 +1,21 @@
-using AssetRegistry
-ps = addprocs(1)
-
+ENV["JULIA_ASSETREGISTRY_BASEURL"] = "/mybasedir"
 @static if VERSION < v"0.7.0-DEV.2005"
     using Base.Test
 else
+    using Distributed
     using Test
 end
+using AssetRegistry
+ps = addprocs(1)
 
 using JSON
 
 @testset "register" begin
     key = AssetRegistry.register(pwd())
+    @test startswith(key, ENV["JULIA_ASSETREGISTRY_BASEURL"])
     @test key == AssetRegistry.getkey(pwd())
     @test AssetRegistry.isregistered(pwd())
-    @test JSON.parse(String(read(joinpath(homedir(), ".jlassetregistry.json")))) == Dict(key => [pwd(), 1])
+    @test JSON.parse(String(read(joinpath(homedir(), ".jlassetregistry.json")))) == Dict(AssetRegistry.filekey(key) => [pwd(), 1])
 
     # test that a new proc doesn't leave any residue
     run(```
@@ -21,7 +23,7 @@ using JSON
         -e 'using AssetRegistry; AssetRegistry.register(pwd());'
         ```)
 
-    @test JSON.parse(String(read(joinpath(homedir(), ".jlassetregistry.json")))) == Dict(key => [pwd(), 1])
+    @test JSON.parse(String(read(joinpath(homedir(), ".jlassetregistry.json")))) == Dict(AssetRegistry.filekey(key) => [pwd(), 1])
 
     AssetRegistry.deregister(pwd())
     @test !AssetRegistry.isregistered(pwd())


### PR DESCRIPTION
This fixes a problem where WebIO and Interact would not work on a notebook running on Jupyterhub, because the `/assetserver` needs to be prefixed. The correct prefix is searched first in the environment variable `JULIA_ASSETREGISTRY_BASEURL` and then in `JUPYTERHUB_SERVICE_PREFIX`. The latter is set automatically on jupyterhub, allowing the packages to work without additional configuration.

I think this also obsoletes https://github.com/JuliaGizmos/WebIO.jl/pull/154, with the added benefit that it works for both WebIO and Interact.

Note that to make this work the key stored in the .json omits the prefix, while the in-memory key keeps it. I'm not sure if that's the most elegant solution, but it's the only way I could find without also modifying at least WebIO.