### PR TITLE
Removed stdlib SHA from REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,3 @@
 julia 0.7
 Pidfile
-SHA
 JSON


### PR DESCRIPTION
SHA is now a stdlib so it does not belong in the REQUIRE, see https://github.com/JuliaLang/METADATA.jl/pull/17476