### PR TITLE
use JSON3 to fix type instability and improve performance

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,13 @@
+name = "AssetRegistry"
+uuid = "bf4720bc-e11a-5d0c-854e-bdca1663c893"
+license = "MIT"
+version = "0.1.0"
+
+[deps]
+JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
+Pidfile = "fa939f87-e72e-5be4-a000-7fc836dbe307"
+SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[compat]
+JSON3 = "1.9"
+Pidfile = "1.2.0"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,0 @@
-julia 0.7
-Pidfile
-JSON

--- a/src/AssetRegistry.jl
+++ b/src/AssetRegistry.jl
@@ -27,7 +27,9 @@ julia> key = AssetRegistry.register("/Users/ranjan/.julia/v0.6/Tachyons/assets/t
 """
 function register(path; registry_file = joinpath(homedir(), ".jlassetregistry.json"))
     target = gettarget(path)
-    (isfile(target) || isdir(target)) || error("Asset not found")
+    if !ispath(target)
+        error("Asset not found")
+    end
 
     key = getkey(target)
     if haskey(registry, key)

--- a/src/AssetRegistry.jl
+++ b/src/AssetRegistry.jl
@@ -26,7 +26,7 @@ julia> key = AssetRegistry.register("/Users/ranjan/.julia/v0.6/Tachyons/assets/t
 ```
 """
 function register(path; registry_file = joinpath(homedir(), ".jlassetregistry.json"))
-    target = normpath(abspath(expanduser(path)))
+    target = gettarget(path)
     (isfile(target) || isdir(target)) || error("Asset not found")
 
     key = getkey(target)
@@ -36,64 +36,29 @@ function register(path; registry_file = joinpath(homedir(), ".jlassetregistry.js
     end
 
     # update global registry file
-
-    # touch(registry_file) -- this doesn't work on Azure fs
-    if !isfile(registry_file)
-        # WARN: may need a lock here
-        open(_->nothing, registry_file, "w")
-    end
-
-    pidlock = joinpath(homedir(), ".jlassetregistry.lock")
-
-    withlock(pidlock) do
-        fkey = filekey(key)
-        io = open(registry_file, "r+") # open in read-and-write mode
-        # first get existing entries
-        DT = Dict{String,Tuple{String,Int}}
-        prev_registry =  filesize(io) > 0 ? JSON3.read(io, DT) : DT()
-
+    update_registry_file(registry_file, key) do prev_registry, fkey
         if haskey(prev_registry, fkey)
             prev_registry[fkey] = (target, prev_registry[fkey][2]+1) # increment ref count
         else
             prev_registry[fkey] = (target, 1) # init refcount to 1
         end
-
-        # write the updated registry to file
-        seekstart(io)
-        JSON3.write(io, prev_registry)
-
-        # truncate it to current length
-        truncate(io, position(io))
-        close(io)
     end
 
     registry[key] = target # keep this in current process memory
 
-
-    key
+    return key
 end
 
 function deregister(path; registry_file = joinpath(homedir(), ".jlassetregistry.json"))
-    target = normpath(abspath(expanduser(path)))
+    target = gettarget(path)
 
     key = getkey(target)
     if !haskey(registry, key)
-        return
+        return nothing
     end
-
     pop!(registry, key)
 
-    touch(registry_file)
-
-    pidlock = joinpath(homedir(), ".jlassetregistry.lock")
-    withlock(pidlock) do
-        fkey = filekey(key)
-        io = open(registry_file, "r+")
-
-        # get existing information
-        DT = Dict{String,Tuple{String,Int}}
-        prev_registry =  filesize(io) > 0 ? JSON3.read(io, DT) : DT()
-
+    update_registry_file(registry_file, key) do prev_registry, fkey
         if haskey(prev_registry, fkey)
             val, count = prev_registry[fkey]
             if count == 1
@@ -102,17 +67,35 @@ function deregister(path; registry_file = joinpath(homedir(), ".jlassetregistry.
                 prev_registry[fkey] = (val, count-1) # increment ref count
             end
         end
+    end
 
+    return key
+end
+
+function update_registry_file(f, file, key)
+    pidlock = joinpath(homedir(), ".jlassetregistry.lock")
+    # touch(registry_file) -- this doesn't work on Azure fs
+    if !isfile(file)
+        # WARN: may need a lock here
+        open(_ -> nothing, file, "w")
+    end
+    withlock(pidlock) do
+        fkey = filekey(key)
+        io = open(file, "r+")
+        # get existing information
+        DT = Dict{String,Tuple{String,Int}}
+        prev_registry =  filesize(io) > 0 ? JSON3.read(io, DT) : DT()
+        f(prev_registry, fkey)
+        # write the updated registry to file
         seekstart(io)
         JSON3.write(io, prev_registry)
-
         # truncate it to current length
         truncate(io, position(io))
         close(io)
     end
-
-    key
 end
+
+gettarget(path) = normpath(abspath(expanduser(path)))
 
 getkey(path) =  baseurl[] * "/assetserver/" * bytes2hex(sha1(abspath(path))) * "-" * basename(path)
 
@@ -125,6 +108,12 @@ function __init__()
             AssetRegistry.deregister(path)
         end
     end
+end
+
+# Precompile with a dummy registration
+let
+    register(pwd())
+    deregister(pwd())
 end
 
 end # module


### PR DESCRIPTION
The compile time of Interact.jl (and probably other packages that use AssetRegistry) is hugely affected by JSON serialisation of the asset registry. Currently its not type stable, because JSON does not detect tuples, but mixed type vectors (the areas with the label are AssetRregistry.jl):

![2022-01-21-121855_1920x1080_scrot](https://user-images.githubusercontent.com/2534009/150519276-ddadc0d2-5e59-48e5-b5c4-b9dbb4a70da8.png)

Using JSON 3 and specifying the type lets us use tuple:

![2022-01-21-122445_1920x1080_scrot](https://user-images.githubusercontent.com/2534009/150519277-90f91413-fbde-4b38-bc72-83836c75f11c.png)

These are the flame graphs for `@profile Interact.slider(1:10)`. The time goes from over 15 seconds on my laptop on master, to 5-7 seconds with this PR. 