### PR TITLE
Downgrade version number to v0.1.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AssetRegistry"
 uuid = "bf4720bc-e11a-5d0c-854e-bdca1663c893"
-version = "0.2.0"
+version = "0.1.1"
 
 [deps]
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"


### PR DESCRIPTION
In relation to the discussion in https://github.com/JuliaGizmos/AssetRegistry.jl/pull/14#discussion_r2445334321, restricting supported julia versions is ***not*** a breaking change, it only warrants bumping the second non-zero version number, which from v0.1.0 is v0.1.1

Can someone tag a new version after this?  There haven't been new releases in 8 (eight) years, and this is preventing downstream packages from updating: https://github.com/JuliaRegistries/Registrator.jl/pull/464#issuecomment-3764206844